### PR TITLE
Change to go.1.21 in workflows

### DIFF
--- a/.github/workflows/dependabot_pr.yaml
+++ b/.github/workflows/dependabot_pr.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: ">=1.21.1"
+          go-version: "1.21.x"
           cache-dependency-path: ./go.sum
       - run: make test
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: ">=1.21.1"
+          go-version: "1.21.x"
           cache-dependency-path: ./go.sum
       - run: make test
 


### PR DESCRIPTION
Current version of controller-gen used in this project has issues with go 1.22.